### PR TITLE
Replace `[GitHub username]` with `OpenZeppelin`

### DIFF
--- a/01-defender-meta-txs/README.md
+++ b/01-defender-meta-txs/README.md
@@ -50,7 +50,7 @@ To run the workshop code yourself on the xDai network you will need to [sign up 
 First fork the repository and then Git Clone your fork to your computer and install dependencies
 
 ```js
-$ git clone https://github.com/[GitHub username]/workshops.git
+$ git clone https://github.com/OpenZeppelin/workshops.git
 $ cd workshops/01-defender-meta-txs/
 $ yarn
 ```

--- a/25-defender-metatx-api/README.md
+++ b/25-defender-metatx-api/README.md
@@ -54,7 +54,7 @@ To run the workshop code yourself you will need to [sign up to Defender](https:/
 First fork the repository and then Git Clone your fork to your computer and install dependencies
 
 ```js
-$ git clone https://github.com/[GitHub username]/workshops.git
+$ git clone https://github.com/OpenZeppelin/workshops.git
 $ cd workshops/25-defender-metatx-api/
 $ yarn
 ```


### PR DESCRIPTION
Fixes
https://docs.openzeppelin.com/defender/guide-metatx#configure-project
<img width="590" alt="image" src="https://user-images.githubusercontent.com/168856/187088712-440db2f7-751a-4c30-bb6c-b0ad3ddd637d.png">
